### PR TITLE
ci: build, smoke-test, and publish u-boot to OpenIPC/firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,186 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 4 V1 SoCs from this repo, each with its own _config target.
+        # No mini-boot wrapper — u-boot.bin is the published artifact.
+        include:
+          - { soc: hi3516cv100, config: hi3516c_config }
+          - { soc: hi3518av100, config: hi3518a_config }
+          - { soc: hi3518cv100, config: hi3518c_config }
+          - { soc: hi3518ev100, config: hi3518e_config }
+
+    steps:
+      - name: Install 32-bit libs
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq zlib1g:i386 libc6:i386 libstdc++6:i386
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache toolchain
+        id: cache-tc
+        uses: actions/cache@v4
+        with:
+          path: toolchain
+          key: arm-hisiv100nptl-linux-v1
+
+      - name: Download toolchain
+        if: steps.cache-tc.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v1 -R OpenIPC/toolchains \
+            -p 'arm-hisiv100nptl-linux.tgz'
+          mkdir -p toolchain
+          tar xzf arm-hisiv100nptl-linux.tgz -C toolchain
+          rm arm-hisiv100nptl-linux.tgz
+          # The outer tarball is named -nptl- but the inner directory
+          # is just arm-hisiv100-linux/. Extract any nested .tar.bz2
+          # we find under the extracted tree.
+          for t in toolchain/*/arm-hisiv100*linux.tar.bz2; do
+            [ -f "$t" ] && tar xjf "$t" -C toolchain
+          done
+
+      - name: Build
+        run: |
+          # Inner tar extracts to arm-hisiv100-linux/bin/ (the outer
+          # package is named arm-hisiv100nptl-linux but the inner
+          # toolchain just calls itself arm-hisiv100-linux). Use the
+          # long-form CROSS_COMPILE to skip the short-name symlink
+          # dance the other repos need.
+          export PATH="$PWD/toolchain/arm-hisiv100-linux/bin:$PATH"
+          which arm-hisiv100-linux-uclibcgnueabi-gcc
+          export CROSS_COMPILE=arm-hisiv100-linux-uclibcgnueabi-
+          make CROSS_COMPILE="$CROSS_COMPILE" ${{ matrix.config }}
+          # SUBDIRS= skips examples/standalone — only u-boot.bin ships.
+          make CROSS_COMPILE="$CROSS_COMPILE" -j$(nproc) SUBDIRS= u-boot.bin
+          cp u-boot.bin u-boot-${{ matrix.soc }}-universal.bin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: u-boot-${{ matrix.soc }}-universal
+          path: u-boot-${{ matrix.soc }}-universal.bin
+
+  qemu_smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only hi3516cv100 has a QEMU machine in widgetii/qemu-hisilicon
+        # right now. The hi3518a/c/e v100 binaries publish unguarded.
+        include:
+          - { soc: hi3516cv100, machine: hi3516cv100, flash_type: hisi-sfc350 }
+    steps:
+      - name: Install QEMU build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            build-essential ninja-build meson pkg-config \
+            libglib2.0-dev libpixman-1-dev libfdt-dev zlib1g-dev \
+            libslirp-dev python3 python3-venv
+
+      - name: Resolve qemu-hisilicon HEAD
+        id: qemu-rev
+        run: |
+          sha=$(git ls-remote https://github.com/widgetii/qemu-hisilicon master | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Cache qemu-system-arm
+        id: cache-qemu
+        uses: actions/cache@v4
+        with:
+          path: qemu-arm
+          key: qemu-hisilicon-${{ steps.qemu-rev.outputs.sha }}
+
+      - name: Build qemu-system-arm (cache miss)
+        if: steps.cache-qemu.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch master \
+            https://github.com/widgetii/qemu-hisilicon qemu-hisilicon
+          cd qemu-hisilicon
+          bash qemu/setup.sh
+          cp qemu-src/build/qemu-system-arm "$GITHUB_WORKSPACE/qemu-arm"
+          chmod +x "$GITHUB_WORKSPACE/qemu-arm"
+
+      - name: Download u-boot artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: u-boot-${{ matrix.soc }}-universal
+
+      - name: Smoke-test in QEMU
+        timeout-minutes: 2
+        run: |
+          UBOOT="$PWD/u-boot-${{ matrix.soc }}-universal.bin"
+          test -f "$UBOOT"
+          dd if=/dev/zero of=/tmp/flash.bin bs=1M count=8 2>/dev/null
+          dd if="$UBOOT" of=/tmp/flash.bin bs=1 conv=notrunc 2>/dev/null
+          mkfifo /tmp/uart.in /tmp/uart.out
+          chmod +x ./qemu-arm
+          # cv100 uses the hisi-sfc350 SPI controller, not the default
+          # hisi-fmc — same as widgetii/qemu-hisilicon's own boot test.
+          ./qemu-arm \
+            -M ${{ matrix.machine }} \
+            -global ${{ matrix.flash_type }}.flash-file=/tmp/flash.bin \
+            -nographic -serial pipe:/tmp/uart \
+            -monitor none > /tmp/qemu.log 2>&1 &
+          QEMU_PID=$!
+          timeout 10 cat /tmp/uart.out > /tmp/uboot.txt || true
+          kill "$QEMU_PID" 2>/dev/null || true
+          wait 2>/dev/null || true
+          echo "== captured u-boot output =="
+          cat /tmp/uboot.txt
+          echo
+          if grep -qE 'U-Boot |Hit any key|CPU:|DRAM:|Board:' /tmp/uboot.txt; then
+            echo "PASS: u-boot booted past System startup"
+          else
+            echo "FAIL: u-boot did not get past System startup"
+            tail -40 /tmp/qemu.log || true
+            exit 1
+          fi
+
+  publish:
+    needs: [build, qemu_smoke]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload to OpenIPC/firmware latest release
+        env:
+          GH_TOKEN: ${{ secrets.FIRMWARE_RELEASE_TOKEN }}
+        run: |
+          set -eu
+          upload() {
+            local f="$1" i
+            for i in 1 2 3 4 5; do
+              if gh release upload latest "$f" --clobber -R OpenIPC/firmware; then
+                return 0
+              fi
+              [ "$i" = "5" ] && return 1
+              echo "upload attempt $i failed; sleeping $((i*10))s" >&2
+              sleep $((i*10))
+            done
+          }
+          for soc in hi3516cv100 hi3518av100 hi3518cv100 hi3518ev100; do
+            f="artifacts/u-boot-${soc}-universal/u-boot-${soc}-universal.bin"
+            test -f "$f"
+            upload "$f"
+          done


### PR DESCRIPTION
Adds CI for all four V1 SoCs (Hi3516CV100, Hi3518AV100, Hi3518CV100, Hi3518EV100). Same shape as the rest of the rollout, with two repo-specific tweaks:

- This repo ships u-boot.bin directly (no mini-boot LZMA wrapper).
- QEMU smoke uses `hisi-sfc350` flash controller (matches widgetii/qemu-hisilicon's own cv100 ping test), not the default `hisi-fmc` used by the V2+ repos.

qemu_smoke covers hi3516cv100 only — the other three V1 variants don't have QEMU machines yet. Requires the org-level FIRMWARE_RELEASE_TOKEN secret.