### PR TITLE
ci: gate hi3518a/c/e v100 qemu_smoke (qemu-hisilicon#78)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,11 +96,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # All four V1 SoCs in this repo are now testable: qemu-
-        # hisilicon#78 added hi3518a/c/e v100 as die-identical clones
-        # of cv100 (same ARM926EJ-S, 0x20xxxxxx address map, HISFC350
-        # flash, peripheral layout — disambiguated only by the
-        # SCSYSID0 0x88/0x8C chip-id registers ipctool reads).
         include:
           - { soc: hi3516cv100, machine: hi3516cv100, flash_type: hisi-sfc350 }
           - { soc: hi3518av100, machine: hi3518av100, flash_type: hisi-sfc350 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,10 +96,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Only hi3516cv100 has a QEMU machine in widgetii/qemu-hisilicon
-        # right now. The hi3518a/c/e v100 binaries publish unguarded.
+        # All four V1 SoCs in this repo are now testable: qemu-
+        # hisilicon#78 added hi3518a/c/e v100 as die-identical clones
+        # of cv100 (same ARM926EJ-S, 0x20xxxxxx address map, HISFC350
+        # flash, peripheral layout — disambiguated only by the
+        # SCSYSID0 0x88/0x8C chip-id registers ipctool reads).
         include:
           - { soc: hi3516cv100, machine: hi3516cv100, flash_type: hisi-sfc350 }
+          - { soc: hi3518av100, machine: hi3518av100, flash_type: hisi-sfc350 }
+          - { soc: hi3518cv100, machine: hi3518cv100, flash_type: hisi-sfc350 }
+          - { soc: hi3518ev100, machine: hi3518ev100, flash_type: hisi-sfc350 }
     steps:
       - name: Install QEMU build deps
         run: |


### PR DESCRIPTION
## Summary

widgetii/qemu-hisilicon#78 added the V1 trio (`hi3518av100`,
`hi3518cv100`, `hi3518ev100`) as die-identical clones of
`hi3516cv100` — same ARM926EJ-S, `0x20xxxxxx` address map,
HISFC350 flash, peripheral layout. Disambiguated only by the
SCSYSID0 `0x88`/`0x8C` chip-id registers ipctool reads.

Adds all three to the qemu_smoke matrix; all four V1 SoCs in this
repo are now gated. Closes the last QEMU gap in this repo.

## Test plan

- [ ] CI `qemu_smoke` job passes for all four SoCs.
- [ ] Existing cv100 smoke still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)