### PR TITLE
ci: use unified -M $machine,flash-file=$f syntax (qemu-hisilicon#80)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,10 +97,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { soc: hi3516cv100, machine: hi3516cv100, flash_type: hisi-sfc350 }
-          - { soc: hi3518av100, machine: hi3518av100, flash_type: hisi-sfc350 }
-          - { soc: hi3518cv100, machine: hi3518cv100, flash_type: hisi-sfc350 }
-          - { soc: hi3518ev100, machine: hi3518ev100, flash_type: hisi-sfc350 }
+          - { soc: hi3516cv100, machine: hi3516cv100 }
+          - { soc: hi3518av100, machine: hi3518av100 }
+          - { soc: hi3518cv100, machine: hi3518cv100 }
+          - { soc: hi3518ev100, machine: hi3518ev100 }
     steps:
       - name: Install QEMU build deps
         run: |
@@ -147,11 +147,8 @@ jobs:
           dd if="$UBOOT" of=/tmp/flash.bin bs=1 conv=notrunc 2>/dev/null
           mkfifo /tmp/uart.in /tmp/uart.out
           chmod +x ./qemu-arm
-          # cv100 uses the hisi-sfc350 SPI controller, not the default
-          # hisi-fmc — same as widgetii/qemu-hisilicon's own boot test.
           ./qemu-arm \
-            -M ${{ matrix.machine }} \
-            -global ${{ matrix.flash_type }}.flash-file=/tmp/flash.bin \
+            -M ${{ matrix.machine }},flash-file=/tmp/flash.bin \
             -nographic -serial pipe:/tmp/uart \
             -monitor none > /tmp/qemu.log 2>&1 &
           QEMU_PID=$!


### PR DESCRIPTION
## Summary

widgetii/qemu-hisilicon#80 / #81 added a machine-level `flash-file`
property that forwards to whichever flash controller the SoC config
wires up. The CI workflow no longer needs to know controller names.

Replaces:
```
-M $machine \\
-global hisi-fmc.flash-file=$f \\
```
(or the `hisi-sfc350` variant) with the uniform:
```
-M $machine,flash-file=$f \\
```

Identical smoke step across all 8 OpenIPC HiSi u-boot workflows now.

## Test plan

- [ ] CI `qemu_smoke` job passes on every matrix entry — same
      `PASS: u-boot booted past System startup` output as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)